### PR TITLE
Add SimForge AI scaffold

### DIFF
--- a/simforge-ai/.env.example
+++ b/simforge-ai/.env.example
@@ -1,0 +1,5 @@
+MONGO_URL=mongodb://mongo:27017
+LLAMA_ENDPOINT=https://api.llama.local/v1
+LLAMA_API_KEY=your-key
+GATEWAY_URL=http://gateway:8000
+NEXT_PUBLIC_GATEWAY_URL=http://localhost:8000

--- a/simforge-ai/README.md
+++ b/simforge-ai/README.md
@@ -1,0 +1,16 @@
+# SimForge AI
+
+## Quick Start
+1. `cp .env.example .env` and fill your LLAMA endpoint and key.
+2. Ensure VelociDrone is installed and 'Open using Rosetta' is checked in Finder > Get Info.
+3. Run `docker compose up --build`.
+4. Visit [http://localhost:3000/dashboard](http://localhost:3000/dashboard).
+5. Paste the sample text below and click **Forge**:
+
+```
+Attack run on container yard. Approach from east, crosswind 10kts, 3 laps.
+```
+
+## Troubleshooting
+- If VelociDrone fails to launch, verify the application path in `gateway/main.py` and that it is set to run under Rosetta.
+- For OpenGL errors, toggle the Rosetta option off and on again in the app's Get Info pane.

--- a/simforge-ai/backend/gateway/Dockerfile
+++ b/simforge-ai/backend/gateway/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn","main:app","--host","0.0.0.0","--port","8000","--reload"]

--- a/simforge-ai/backend/gateway/main.py
+++ b/simforge-ai/backend/gateway/main.py
@@ -1,0 +1,59 @@
+import os
+from datetime import datetime
+from fastapi import FastAPI
+import httpx
+import motor.motor_asyncio
+from .models import ForgePayload, TelemetryPayload
+from .mission_compiler import write_mission
+import socketio
+import subprocess
+
+MONGO_URL = os.getenv("MONGO_URL", "mongodb://localhost:27017")
+LLAMA_ENDPOINT = os.getenv("LLAMA_ENDPOINT")
+LLAMA_API_KEY = os.getenv("LLAMA_API_KEY")
+
+mongo_client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_URL)
+db = mongo_client.simforge
+
+sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+app = FastAPI()
+app = socketio.ASGIApp(sio, other_asgi_app=app)
+
+@app.post("/forge")
+async def forge(payload: ForgePayload):
+    headers = {"Authorization": f"Bearer {LLAMA_API_KEY}"}
+    data = {"prompt": payload.thread_text}
+    if payload.image_url:
+        data["image_url"] = payload.image_url
+    async with httpx.AsyncClient() as client:
+        res = await client.post(LLAMA_ENDPOINT, json=data, headers=headers)
+        res.raise_for_status()
+        meta = res.json()
+    mission_name, path = write_mission(meta)
+    subprocess.Popen(["open", "/Applications/VelociDrone.app", "--args", "-start"])
+    doc = {
+        "mission_name": mission_name,
+        "meta": meta,
+        "created": datetime.utcnow(),
+        "scores": []
+    }
+    await db.missions.insert_one(doc)
+    return {"mission_name": mission_name, "created": doc["created"]}
+
+@app.post("/telemetry")
+async def telemetry(data: TelemetryPayload):
+    await db.missions.update_one(
+        {"mission_name": data.mission},
+        {"$push": {"scores": {"pilot": data.pilot, "lap_time_sec": data.lap_time_sec}}}
+    )
+    await sio.emit("score_update", data.model_dump())
+    return {"status": "ok"}
+
+@app.get("/missions")
+async def missions():
+    cursor = db.missions.find().sort("created", -1)
+    items = []
+    async for doc in cursor:
+        doc["_id"] = str(doc["_id"])
+        items.append(doc)
+    return items

--- a/simforge-ai/backend/gateway/mission_compiler.py
+++ b/simforge-ai/backend/gateway/mission_compiler.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+from typing import Dict, Tuple
+
+TEMPLATE_DIR = Path(__file__).parent / "mission_templates"
+MISSION_DIR = Path.home() / "Library/Application Support/VelociDrone/tracks/custom"
+
+env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+
+def write_mission(data: Dict) -> Tuple[str, str]:
+    name = f"{data.get('terrain','mission')}-{int(datetime.utcnow().timestamp())}"
+    safe_name = ''.join(c for c in name if c.isalnum() or c in '-_')
+    template = env.get_template('fpv_base.mission')
+    content = template.render(**data)
+    MISSION_DIR.mkdir(parents=True, exist_ok=True)
+    path = MISSION_DIR / f"{safe_name}.mission"
+    path.write_text(content)
+    return safe_name, str(path)

--- a/simforge-ai/backend/gateway/mission_templates/fpv_base.mission
+++ b/simforge-ai/backend/gateway/mission_templates/fpv_base.mission
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<mission>
+  <terrain>{{ terrain }}</terrain>
+  <threats>
+  {% for t in threats %}
+    <threat>{{ t }}</threat>
+  {% endfor %}
+  </threats>
+  <wind>{{ wind_kts }}</wind>
+  <laps>{{ laps }}</laps>
+</mission>

--- a/simforge-ai/backend/gateway/models.py
+++ b/simforge-ai/backend/gateway/models.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from pydantic import BaseModel
+from typing import List, Optional
+
+class ForgePayload(BaseModel):
+    thread_text: str
+    image_url: Optional[str] = None
+
+class MissionMeta(BaseModel):
+    terrain: str
+    threats: List[str] = []
+    wind_kts: int
+    laps: int
+
+class TelemetryPayload(BaseModel):
+    mission: str
+    pilot: str
+    lap_time_sec: float
+
+class MissionEntry(BaseModel):
+    mission_name: str
+    meta: MissionMeta
+    created: datetime
+    scores: list

--- a/simforge-ai/backend/gateway/requirements.txt
+++ b/simforge-ai/backend/gateway/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+httpx
+motor
+pydantic>=2
+jinja2
+python-dotenv
+python-socketio

--- a/simforge-ai/docker-compose.yml
+++ b/simforge-ai/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+  gateway:
+    build: ./backend/gateway
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend/gateway:/app
+    environment:
+      - MONGO_URL=${MONGO_URL}
+      - LLAMA_ENDPOINT=${LLAMA_ENDPOINT}
+      - LLAMA_API_KEY=${LLAMA_API_KEY}
+  nextjs:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+    environment:
+      - NEXT_PUBLIC_GATEWAY_URL=http://localhost:8000
+      - GATEWAY_URL=http://gateway:8000
+    command: npm run dev

--- a/simforge-ai/frontend/Dockerfile
+++ b/simforge-ai/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+CMD ["npm","run","dev"]

--- a/simforge-ai/frontend/app/api/forge/route.ts
+++ b/simforge-ai/frontend/app/api/forge/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const res = await fetch(`${process.env.GATEWAY_URL}/forge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/simforge-ai/frontend/app/api/missions/route.ts
+++ b/simforge-ai/frontend/app/api/missions/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const res = await fetch(`${process.env.GATEWAY_URL}/missions`);
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/simforge-ai/frontend/app/dashboard/page.tsx
+++ b/simforge-ai/frontend/app/dashboard/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { useState, useEffect } from 'react';
+import io from 'socket.io-client';
+
+type Mission = {
+  mission_name: string;
+  created: string;
+  scores: { pilot: string; lap_time_sec: number }[];
+};
+
+const socket = io(process.env.NEXT_PUBLIC_GATEWAY_URL ?? 'http://localhost:8000');
+
+export default function Dashboard() {
+  const [thread, setThread] = useState('');
+  const [image, setImage] = useState('');
+  const [missions, setMissions] = useState<Mission[]>([]);
+  const [leaderboard, setLeaderboard] = useState<{pilot:string;lap:number}[]>([]);
+
+  useEffect(() => {
+    fetch('/api/missions').then(res => res.json()).then(setMissions);
+    socket.on('score_update', (data) => {
+      setLeaderboard(lb => [...lb, {pilot: data.pilot, lap: data.lap_time_sec}]);
+    });
+  }, []);
+
+  const forge = async () => {
+    await fetch('/api/forge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ thread_text: thread, image_url: image || null })
+    });
+    setThread('');
+    setImage('');
+    fetch('/api/missions').then(res => res.json()).then(setMissions);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">SimForge Dashboard</h1>
+      <textarea className="w-full p-2 border" rows={4} value={thread} onChange={e => setThread(e.target.value)} placeholder="Paste tactics thread..." />
+      <input className="w-full p-2 border" value={image} onChange={e => setImage(e.target.value)} placeholder="Image URL (optional)" />
+      <button className="px-4 py-2 bg-blue-600 text-white" onClick={forge}>Forge</button>
+      <h2 className="font-semibold">Mission History</h2>
+      <ul>
+        {missions.map(m => (
+          <li key={m.mission_name}>{m.mission_name} - {new Date(m.created).toLocaleString()}</li>
+        ))}
+      </ul>
+      <h2 className="font-semibold">Leaderboard</h2>
+      <ul>
+        {leaderboard.map((s,i) => (
+          <li key={i}>{s.pilot}: {s.lap.toFixed(2)}s</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/simforge-ai/frontend/app/globals.css
+++ b/simforge-ai/frontend/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/simforge-ai/frontend/app/layout.tsx
+++ b/simforge-ai/frontend/app/layout.tsx
@@ -1,0 +1,12 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50 text-gray-800">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/simforge-ai/frontend/app/page.tsx
+++ b/simforge-ai/frontend/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main className="flex items-center justify-center h-screen">
+      <a className="text-blue-500 underline" href="/dashboard">Go to Dashboard</a>
+    </main>
+  );
+}

--- a/simforge-ai/frontend/next-env.d.ts
+++ b/simforge-ai/frontend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+declare module '*.css';

--- a/simforge-ai/frontend/next.config.js
+++ b/simforge-ai/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: { appDir: true },
+};
+
+module.exports = nextConfig;

--- a/simforge-ai/frontend/package.json
+++ b/simforge-ai/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "simforge-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "socket.io-client": "^4.7.2"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.3.5",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "typescript": "^5.2.2"
+  }
+}

--- a/simforge-ai/frontend/postcss.config.js
+++ b/simforge-ai/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/simforge-ai/frontend/tailwind.config.js
+++ b/simforge-ai/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./app/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/simforge-ai/frontend/tsconfig.json
+++ b/simforge-ai/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold backend and frontend for SimForge AI
- add FastAPI gateway with mission compiler
- create Next.js 14 dashboard with Tailwind
- add Docker setup with MongoDB

## Testing
- `python3 -m py_compile simforge-ai/backend/gateway/*.py`

------
https://chatgpt.com/codex/tasks/task_b_683ddf99c7cc832183baf5ef4bc04b44